### PR TITLE
added support in model client for multiple models

### DIFF
--- a/src/main/java/edu/twitter/model/client/ModelClient.java
+++ b/src/main/java/edu/twitter/model/client/ModelClient.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 public final class ModelClient {
     private static final CloseableHttpClient HTTP_CLIENT = HttpClients.createDefault();
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String API_URL = "http://localhost:8080/classify?tweet=";
+    private static final String API_URL_TEMPLATE = "http://localhost:8080/%s/classify?tweet=%s";
 
     /**
      * Constructor.
@@ -33,12 +33,14 @@ public final class ModelClient {
      * Perform a Get request to the model's service
      * to get the label of the tweet.
      *
-     * @param tweet tweet's text
+     * @param modelName name of the target model.
+     * @param tweet     tweet's text
      * @return optional of `ModelServiceResponse`
      */
-    public static Optional<ModelServiceResponse> callModelService(final String tweet) {
+    public static Optional<ModelServiceResponse> callModelService(final String modelName, final String tweet) {
         final String encodedTweet = new String(Base64.getUrlEncoder().encode(tweet.getBytes(StandardCharsets.UTF_16)));
-        return executeRequest(API_URL + encodedTweet, ModelServiceResponse.class);
+        final String url = String.format(API_URL_TEMPLATE, modelName, encodedTweet);
+        return executeRequest(url, ModelServiceResponse.class);
     }
 
     /**

--- a/src/main/scala/edu/twitter/SentimentAnalyzer.scala
+++ b/src/main/scala/edu/twitter/SentimentAnalyzer.scala
@@ -3,7 +3,7 @@ package edu.twitter
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import edu.twitter.classification.Classifier
-import edu.twitter.model.impl.gradientboosting.GradientBoostingBuilder
+import edu.twitter.model.impl.gradientboosting.{GradientBoostingBuilder, GradientBoostingModel}
 import edu.twitter.model.service.ModelService
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -33,7 +33,7 @@ object SentimentAnalyzer extends App {
   modelService.start()
 
   val classifier = new Classifier(ssc)
-  val classifiedStream = classifier.createClassifiedStream()
+  val classifiedStream = classifier.createClassifiedStream(GradientBoostingModel.name)
   classifiedStream.foreachRDD(EsSpark.saveToEs(_, "twitter/sentiment"))
 
   ssc.start()

--- a/src/main/scala/edu/twitter/SentimentAnalyzer.scala
+++ b/src/main/scala/edu/twitter/SentimentAnalyzer.scala
@@ -34,7 +34,7 @@ object SentimentAnalyzer extends App {
 
   val classifier = new Classifier(ssc)
   val classifiedStream = classifier.createClassifiedStream(GradientBoostingModel.name)
-  classifiedStream.foreachRDD(EsSpark.saveToEs(_, "twitter/sentiment"))
+  classifiedStream.foreachRDD(EsSpark.saveToEs(_, s"${GradientBoostingModel.name}/classified-stream"))
 
   ssc.start()
   ssc.awaitTermination()

--- a/src/main/scala/edu/twitter/classification/Classifier.scala
+++ b/src/main/scala/edu/twitter/classification/Classifier.scala
@@ -24,9 +24,10 @@ class Classifier(ssc: StreamingContext) {
     * Build the `Classification Model` and a `TweeterStream`
     * and return a stream of `ClassifiedTweets`.
     *
+    * @param modelName name of target model.
     * @return stream of `ClassifiedTweets`
     */
-  def createClassifiedStream(): DStream[ClassifiedTweet] = {
+  def createClassifiedStream(modelName: String): DStream[ClassifiedTweet] = {
     val tweets = new TwitterStream(ssc).createStream()
     val supportedLangIso = Set("en", "eng")
     val dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
@@ -34,7 +35,7 @@ class Classifier(ssc: StreamingContext) {
       tweet <- tweets
       if supportedLangIso(tweet.getLang)
       date = dateFormat.format(new Date())
-      resOption = ModelClient.callModelService(tweet.getText)
+      resOption = ModelClient.callModelService(modelName, tweet.getText)
       if resOption.isPresent
       res = resOption.get
     } yield ClassifiedTweet(res.getLabel, tweet.getText, date)

--- a/src/main/scala/edu/twitter/model/impl/gradientboosting/GradientBoostingModel.scala
+++ b/src/main/scala/edu/twitter/model/impl/gradientboosting/GradientBoostingModel.scala
@@ -12,8 +12,8 @@ import org.apache.spark.mllib.tree.model.GradientBoostedTreesModel
 class GradientBoostingModel(model: GradientBoostedTreesModel) extends GenericModel {
 
   val name: String = GradientBoostingModel.name
-  val hashingTF = new HashingTF(2000)
-  val invalidTokens = Set("http", "@", "rt", "#", "RT")
+  private val hashingTF = new HashingTF(2000)
+  private val invalidTokens = Set("http", "@", "rt", "#", "RT")
 
   override def getLabel(tweetText: String): Double = {
     val tokens = tweetText.split(" ").filter(!invalidTokens(_))

--- a/src/main/scala/edu/twitter/model/impl/gradientboosting/GradientBoostingModel.scala
+++ b/src/main/scala/edu/twitter/model/impl/gradientboosting/GradientBoostingModel.scala
@@ -11,7 +11,7 @@ import org.apache.spark.mllib.tree.model.GradientBoostedTreesModel
   */
 class GradientBoostingModel(model: GradientBoostedTreesModel) extends GenericModel {
 
-  val name = "GradientBoosting"
+  val name: String = GradientBoostingModel.name
   val hashingTF = new HashingTF(2000)
   val invalidTokens = Set("http", "@", "rt", "#", "RT")
 
@@ -20,4 +20,10 @@ class GradientBoostingModel(model: GradientBoostedTreesModel) extends GenericMod
     val features = hashingTF.transform(tokens)
     model.predict(features)
   }
+}
+
+/** Companion object for the model
+  * only holding the name. */
+object GradientBoostingModel {
+  val name = "GradientBoosting"
 }

--- a/src/main/scala/edu/twitter/model/impl/neuralnetwork/NeuralNetworkModel.scala
+++ b/src/main/scala/edu/twitter/model/impl/neuralnetwork/NeuralNetworkModel.scala
@@ -18,8 +18,8 @@ import org.nd4j.linalg.indexing.{INDArrayIndex, NDArrayIndex}
 class NeuralNetworkModel(model: MultiLayerNetwork,
                          wordVectors: WordVectors) extends GenericModel {
 
-  val name = "NeuralNetwork"
-  val vectorSize = wordVectors.getWordVector(wordVectors.vocab.wordAtIndex(0)).length
+  val name: String = NeuralNetworkModel.name
+  private val vectorSize = wordVectors.getWordVector(wordVectors.vocab.wordAtIndex(0)).length
 
   /**
     * Classify the given tweet.
@@ -62,4 +62,11 @@ class NeuralNetworkModel(model: MultiLayerNetwork,
   }
 
 
+}
+
+
+/** Companion object for the model
+  * only holding the name. */
+object NeuralNetworkModel {
+  val name = "NeuralNetwork"
 }

--- a/src/main/scala/edu/twitter/model/service/ModelService.scala
+++ b/src/main/scala/edu/twitter/model/service/ModelService.scala
@@ -36,7 +36,7 @@ class ModelService(genericModelBuilder: GenericModelBuilder)
   def start(): Unit = {
     val model = genericModelBuilder.build()
     val route: Route =
-      path("classify") {
+      path(s"${model.name}" / "classify") {
         get {
           parameters('tweet.as[String]) { tweet =>
             val decodedTweet = new String(Base64.getUrlDecoder.decode(tweet), Charset.forName("UTF-16"))

--- a/src/test/scala/edu/twitter/classification/ClassifierTest.scala
+++ b/src/test/scala/edu/twitter/classification/ClassifierTest.scala
@@ -2,7 +2,7 @@ package edu.twitter.classification
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import edu.twitter.model.impl.gradientboosting.GradientBoostingBuilder
+import edu.twitter.model.impl.gradientboosting.{GradientBoostingBuilder, GradientBoostingModel}
 import edu.twitter.model.service.ModelService
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -23,7 +23,7 @@ object ClassifierTest {
     modelService.start()
 
     val classifier = new Classifier(ssc)
-    val classifiedStream = classifier.createClassifiedStream()
+    val classifiedStream = classifier.createClassifiedStream(GradientBoostingModel.name)
     classifiedStream.foreachRDD(rdd => rdd.take(10).foreach(println(_)))
 
     ssc.start()

--- a/src/test/scala/edu/twitter/model/ModelClientServiceTest.scala
+++ b/src/test/scala/edu/twitter/model/ModelClientServiceTest.scala
@@ -17,7 +17,9 @@ object ModelClientServiceTest {
     val modelService = new ModelService(new TestGenericModelBuilder())
     modelService.start()
 
-    val resp = ModelClient.callModelService("hello")
+    val modeName = "TestGenericModel"
+    val tweet = "hello"
+    val resp = ModelClient.callModelService(modeName, tweet)
     println(resp.get().getLabel)
   }
 


### PR DESCRIPTION
This PR aims to make the `model client` support calling multiple models by name, this will help if we tend to use multiple models and compare them. we can create multiple `classified streams` and persist all of them then query and compare them in `kibana`.